### PR TITLE
Update tests to use `exist` instead of comparison to `null` and `undefined`

### DIFF
--- a/src/test/test-part2.js
+++ b/src/test/test-part2.js
@@ -57,7 +57,7 @@ describe("Test Part 2", function () {
                     slots = intents[i].slots
                 }
             }
-            expect(slots).is.not.null
+            expect(slots).to.exist
         })
         it('should include a slot named FACT_YEAR', function () {
             var hasCorrectSlot = false;
@@ -90,15 +90,15 @@ describe("Test Part 2", function () {
                 expect(speechError).to.be.null
             })
             it('should have a speechlet response', function () {
-                expect(speechResponse.response).not.to.be.null
+                expect(speechResponse.response).to.exist
             })
 
             it("should have a spoken response", () => {
-                expect(speechResponse.response.outputSpeech).not.to.be.null
+                expect(speechResponse.response.outputSpeech).to.exist
             })
 
             it("should have a card response", () => {
-                expect(speechResponse.response.card).not.to.be.null
+                expect(speechResponse.response.card).to.exist
             })
         })
         describe("The response is functionally correct", function () {

--- a/src/test/test-part3.js
+++ b/src/test/test-part3.js
@@ -41,7 +41,7 @@ describe("Test Part 3", function () {
             it("should have a reprompt available", () => {
                 var msg = speechResponse.response.outputSpeech.ssml;
                 resultArr.push(msg);
-                expect(speechResponse.response.reprompt).not.to.be.undefined
+                expect(speechResponse.response.reprompt).to.exist
             })
         })
         describe("Testing conversational elements of GetNewFactIntent 2 of 3", function () {
@@ -58,7 +58,7 @@ describe("Test Part 3", function () {
                 it("should not end the alexa session", function () {
                     var msg = speechResponse.response.outputSpeech.ssml;
                     resultArr.push(msg);
-                    expect(speechResponse.response.shouldEndSession).not.to.be.null
+                    expect(speechResponse.response.shouldEndSession).to.exist
                     expect(speechResponse.response.shouldEndSession).to.be.false
                 })
             })
@@ -98,7 +98,7 @@ describe("Test Part 3", function () {
             })
             describe("The response keeps the conversation open", function () {
                 it("should have a reprompt available", () => {
-                    expect(speechResponse.response.reprompt).not.to.be.undefined
+                    expect(speechResponse.response.reprompt).to.exist
                 })
                 it("should not end the alexa session", function () {
                     expect(speechResponse.response.shouldEndSession).to.be.false
@@ -117,7 +117,7 @@ describe("Test Part 3", function () {
             })
             describe("The response keeps the conversation open", function () {
                 it("should have a reprompt available", () => {
-                    expect(speechResponse.response.reprompt).not.to.be.undefined
+                    expect(speechResponse.response.reprompt).to.exist
                 })
                 it("should not end the alexa session", function () {
                     expect(speechResponse.response.shouldEndSession).to.be.false

--- a/src/test/test-starter-code.js
+++ b/src/test/test-starter-code.js
@@ -27,27 +27,27 @@ describe("Starter Code Tests", function () {
         })
         describe("The response is structurally correct", function () {
             it('should not have errored', function () {
-                expect(speechError).to.be.null
+                expect(speechError).to.not.exist
             })
 
             it('should have a speechlet response', function () {
-                expect(speechResponse.response).not.to.be.null
+                expect(speechResponse.response).to.exist
             })
 
             it("should have a spoken response", () => {
-                expect(speechResponse.response.outputSpeech).not.to.be.null
+                expect(speechResponse.response.outputSpeech).to.exist
             })
 
             it("should have a card response", () => {
-                expect(speechResponse.response.card).not.to.be.null
+                expect(speechResponse.response.card).to.exist
             })
 
             it("should have a reprompt available", () => {
-                expect(speechResponse.response.reprompt).not.to.be.null
+                expect(speechResponse.response.reprompt).to.exist
             })
 
             it("should not end the alexa session", function () {
-                expect(speechResponse.response.shouldEndSession).not.to.be.null
+                expect(speechResponse.response.shouldEndSession).to.exist
                 expect(speechResponse.response.shouldEndSession).to.be.false
             })
         })
@@ -64,27 +64,27 @@ describe("Starter Code Tests", function () {
         })
         describe("The response is structurally correct", function () {
             it('should not have errored', function () {
-                expect(speechError).to.be.null
+                expect(speechError).to.not.exist
             })
 
             it('should have a speechlet response', function () {
-                expect(speechResponse.response).not.to.be.null
+                expect(speechResponse.response).to.exist
             })
 
             it("should have a spoken response", () => {
-                expect(speechResponse.response.outputSpeech).not.to.be.null
+                expect(speechResponse.response.outputSpeech).to.exist
             })
 
             it("should have no card response", () => {
-                expect(speechResponse.response.card).to.equal.undefined
+                expect(speechResponse.response.card).to.not.exist
             })
 
             it("should have no reprompt", () => {
-                expect(speechResponse.response.reprompt).to.equal.undefined
+                expect(speechResponse.response.reprompt).to.not.exist
             })
 
             it("should end the alexa session", function () {
-                expect(speechResponse.response.shouldEndSession).not.to.be.null
+                expect(speechResponse.response.shouldEndSession).to.exist
                 expect(speechResponse.response.shouldEndSession).to.be.true
             })
         })
@@ -101,27 +101,27 @@ describe("Starter Code Tests", function () {
         })
         describe("The response is structurally correct", function () {
             it('should not have errored', function () {
-                expect(speechError).to.be.null
+                expect(speechError).to.not.exist
             })
 
             it('should have a speechlet response', function () {
-                expect(speechResponse.response).not.to.be.null
+                expect(speechResponse.response).to.exist
             })
 
             it("should have a spoken response", () => {
-                expect(speechResponse.response.outputSpeech).not.to.be.null
+                expect(speechResponse.response.outputSpeech).to.exist
             })
 
             it("should have no card response", () => {
-                expect(speechResponse.response.card).to.equal.undefined
+                expect(speechResponse.response.card).to.not.exist
             })
 
             it("should have no reprompt", () => {
-                expect(speechResponse.response.reprompt).to.equal.undefined
+                expect(speechResponse.response.reprompt).to.not.exist
             })
 
             it("should end the alexa session", function () {
-                expect(speechResponse.response.shouldEndSession).not.to.be.null
+                expect(speechResponse.response.shouldEndSession).to.exist
                 expect(speechResponse.response.shouldEndSession).to.be.true
             })
         })
@@ -140,15 +140,15 @@ describe("Starter Code Tests", function () {
             it('should not have errored', function () {
                 var msg = speechResponse.response.outputSpeech.ssml;
                 resultArr.push(msg);
-                expect(speechError).to.be.null
+                expect(speechError).to.not.exist
             })
 
             it('should have a speechlet response', function () {
-                expect(speechResponse.response).not.to.be.null
+                expect(speechResponse.response).to.exist
             })
 
             it("should have a spoken response", () => {
-                expect(speechResponse.response.outputSpeech).not.to.be.null
+                expect(speechResponse.response.outputSpeech).to.exist
             })
         })
     });
@@ -167,7 +167,7 @@ describe("Starter Code Tests", function () {
             it("should have a card response", () => {
                 var msg = speechResponse.response.outputSpeech.ssml;
                 resultArr.push(msg);
-                expect(speechResponse.response.card).not.to.be.null
+                expect(speechResponse.response.card).to.exist
             })
         })
     });


### PR DESCRIPTION
Hello Dana,

In completing the project I ran into a couple errors with the tests. The two issues I noticed were that `equal`  was crashing and that the Alexa-sdk code was returning an `undefined` when the test was checking for a `null`. Looking into the docs for this testing module I was able to find `exist` which checks if it is not equal to `null` or `undefined`. This commit replaces the `equal`, `null`, and `undefined` comparisons with the equivalent `exist` syntax.

[Chai exist](http://chaijs.com/api/bdd/#method_exist)

- Replace `null` and `undefined` comparisons with `exist` (checks for both)
- Replace `equal` with `exist` check to remove error